### PR TITLE
remove unnecessary imports and add party mode on slide left

### DIFF
--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -313,22 +313,22 @@ export default function Player() {
                 <p className="truncate text-muted-foreground">{currentTrack.artist}</p>
               </div>
               <div className="flex items-center gap-2">
-                <Button
+                {/* <Button
                   variant="ghost"
                   size="icon"
                   onClick={activateKaraokeMode}
                   className="h-10 w-10"
                 >
                   <Mic className="h-5 w-5" />
-                </Button>
-                <Button
+                </Button> */}
+                {/* <Button
                   variant="ghost"
                   size="icon"
                   onClick={() => carouselApi?.scrollNext()}
                   className="h-10 w-10"
                 >
                   <Headphones className="h-5 w-5" />
-                </Button>
+                </Button> */}
                 <Button
                   variant="ghost"
                   size="icon"
@@ -341,7 +341,7 @@ export default function Player() {
                     )}
                   />
                 </Button>
-                <Button
+                {/* <Button
                   variant="secondary"
                   size="icon"
                   className="h-10 w-10"
@@ -351,13 +351,13 @@ export default function Player() {
                   }}
                 >
                   <Users className="h-5 w-5" />
-                </Button>
+                </Button> */}
               </div>
             </div>
           </motion.div>
 
           {/* Listening Party Section */}
-          <motion.div
+          {/* <motion.div
             id="listening-party-section"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -370,7 +370,7 @@ export default function Player() {
                 username={getCurrentUser().username}
               />
             </div>
-          </motion.div>
+          </motion.div> */}
 
           {/* Progress Bar */}
           <motion.div


### PR DESCRIPTION
removed the extra UI buttons on the now playing and added on left swipe activate party mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed karaoke activation button, headphones button, and secondary controls from the normal player view.
  * Disabled Listening Party section visibility in standard player mode. These controls remain available in Karaoke mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->